### PR TITLE
Added a small condition for cleaning url and removed extra '/'

### DIFF
--- a/src/webCrawler.py
+++ b/src/webCrawler.py
@@ -22,7 +22,7 @@ def zulu(start_url):
     if start_url.endswith('/'):
         clean_url = start_url[:-1] #this removes any trailing '/' in the urls
     
-    print(clean_url)       #Housekeeping
+    #print(clean_url)       #Housekeeping
     q.enqueue(clean_url)
     visited = set()
     listed = set()
@@ -41,7 +41,7 @@ def zulu(start_url):
                 continue
             listed.add(link.get('href'))
             temp = link.get('href')
-            print(temp)
+            #print(temp)
             if("mailto" in temp):
                 continue
             elif "http" in temp:

--- a/src/webCrawler.py
+++ b/src/webCrawler.py
@@ -19,8 +19,11 @@ class Queue:
 
 def zulu(start_url):
     q = Queue()
-    #print(start_url)       #Housekeeping
-    q.enqueue(start_url)
+    if start_url.endswith('/'):
+        clean_url = start_url[:-1] #this removes any trailing '/' in the urls
+    
+    print(clean_url)       #Housekeeping
+    q.enqueue(clean_url)
     visited = set()
     listed = set()
     while not q.isEmpty():
@@ -38,16 +41,16 @@ def zulu(start_url):
                 continue
             listed.add(link.get('href'))
             temp = link.get('href')
-            #print(temp)
+            print(temp)
             if("mailto" in temp):
                 continue
-            if "http" in temp:
+            elif "http" in temp:
                 q.enqueue(link.get('href'))
                 print("Crawled URL: " +link.get('href'))
             else:
                 print('Not found URL')
-                q.enqueue(start_url + "/" + link.get('href'))
-                print("Crawled URL: " + start_url + "/" + link.get('href'))
+                q.enqueue(clean_url + link.get('href'))
+                print("Crawled URL: " + clean_url + link.get('href'))
 
                 
 


### PR DESCRIPTION
#5 
I saw that blatantly copying url from browser added a trailing '/' and this was a cause of those '///' in the crawled url.
I also removed the concatenation with the '/' in the crawled urls as the url already have a leading '/' in the websites I provided in my testing.

Test results
<img width="975" alt="Screenshot 2024-04-16 at 1 43 44 PM" src="https://github.com/deydebaditya/zulu/assets/12766730/45e18b5e-4d46-4b1e-8c0a-bffdf56d99d2">

